### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "go"
+run = "make test"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/outillage/commitsar)](https://goreportcard.com/report/github.com/outillage/commitsar)
 [![Build Status](https://cloud.drone.io/api/badges/commitsar-app/commitsar/status.svg)](https://cloud.drone.io/commitsar-app/commitsar)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+[![Run on Repl.it](https://repl.it/badge/github/outillage/commitsar)](https://repl.it/github/outillage/commitsar)
 
 Tool to make sure your commits are compliant with [conventional commits](https://www.conventionalcommits.org). It is aimed mainly at CIs to prevent branches with commits that don't comply. Usage as a pre-commit hook is also under consideration.
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).