### PR TITLE
feat: add from-to flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Tool to make sure your commits are compliant with [conventional commits](https:/
 ## Table of contents
 
 1. [Usage](#usage)
+2. [Flags](#flags)
 
 ## Usage
 
@@ -53,3 +54,20 @@ Adjust for version and distribution. Please check [Releases](https://github.com/
 - tar -xzf commitsar_v0.0.2_Linux_x86_64.tar.gz
 - ./commitsar
 ```
+
+# Flags
+
+Commitsar allows the following flags:
+
+| Name    | Flag | Required | Default |
+| ------- | ---- | -------- | ------- |
+| Verbose | --v  | false    | false   |
+| Strict  | --s  | false    | true    |
+
+On top of that a single argument is allowed:
+
+`commitsar <from commit>...<to commit>`
+
+e.g. `commitsar 7dbf3e7db93ae2e02902cae9d2f1de1b1e5c8c92...d0240d3ed34685d0a5329b185e120d3e8c205be4`
+
+If only one commit hash is used then commitsar will assume it to be the TO commit.

--- a/cmd/commits_between_branches.go
+++ b/cmd/commits_between_branches.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	history "github.com/outillage/git/pkg"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+)
+
+func commitsBetweenBranches(gitRepo *history.Git, upstreamBranch string) ([]plumbing.Hash, error) {
+	var commits []plumbing.Hash
+
+	currentBranch, currentBranchErr := gitRepo.CurrentBranch()
+	if currentBranchErr != nil {
+		return nil, currentBranchErr
+	}
+
+	sameBranch, err := IdentifySameBranch(currentBranch.Name().String(), upstreamBranch, gitRepo)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if sameBranch {
+		commitsOnSameBranch, err := gitRepo.CommitsOnBranch(currentBranch.Hash())
+
+		if err != nil {
+			return nil, err
+		}
+
+		commits = append(commits, commitsOnSameBranch[0])
+
+	} else {
+		commitsOnBranch, err := gitRepo.BranchDiffCommits(currentBranch.Name().String(), upstreamBranch)
+
+		if err != nil {
+			return nil, err
+		}
+
+		commits = commitsOnBranch
+	}
+
+	return commits, nil
+}

--- a/cmd/commits_between_hashes.go
+++ b/cmd/commits_between_hashes.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"strings"
+
+	history "github.com/outillage/git/pkg"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+)
+
+func commitsBetweenHashes(gitRepo *history.Git, args []string) ([]plumbing.Hash, error) {
+	var commits []plumbing.Hash
+	var fromCommit plumbing.Hash
+	var toCommit plumbing.Hash
+
+	arg := args[0]
+
+	splitArgs := strings.Split(arg, "...")
+
+	if len(splitArgs) == 1 {
+		currentCommit, err := gitRepo.CurrentCommit()
+
+		if err != nil {
+			return nil, err
+		}
+
+		fromCommit = currentCommit.Hash
+
+		toCommit = plumbing.NewHash(splitArgs[0])
+	}
+
+	if len(splitArgs) == 2 {
+		fromCommit = plumbing.NewHash(splitArgs[0])
+		toCommit = plumbing.NewHash(splitArgs[1])
+	}
+
+	logCommits, err := gitRepo.CommitsBetween(fromCommit, toCommit)
+
+	if err != nil {
+		return nil, err
+	}
+
+	commits = logCommits
+
+	return commits, nil
+}

--- a/cmd/commits_between_hashes_test.go
+++ b/cmd/commits_between_hashes_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"testing"
+
+	history "github.com/outillage/git/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommitsBetweenHashes(t *testing.T) {
+	gitRepo, err := history.OpenGit("../testdata/commits-on-different-branches", false)
+
+	assert.NoError(t, err)
+
+	commits, err := commitsBetweenHashes(gitRepo, []string{"7dbf3e7db93ae2e02902cae9d2f1de1b1e5c8c92...d0240d3ed34685d0a5329b185e120d3e8c205be4"})
+
+	// TODO: Allow including to commit
+	assert.Len(t, commits, 1)
+	assert.NoError(t, err)
+}
+
+func TestCommitsBetweenHashesOnlyTo(t *testing.T) {
+	gitRepo, err := history.OpenGit("../testdata/commits-on-different-branches", false)
+
+	assert.NoError(t, err)
+
+	commits, err := commitsBetweenHashes(gitRepo, []string{"d0240d3ed34685d0a5329b185e120d3e8c205be4"})
+
+	assert.Len(t, commits, 2)
+	assert.NoError(t, err)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:           "commitsar",
+	Use:           "commitsar <from?>...<to>",
 	Short:         "Checks if commits comply",
 	Long:          "Checks if commits comply with conventional commits",
 	RunE:          runRoot,
@@ -53,5 +53,5 @@ func runRoot(cmd *cobra.Command, args []string) error {
 
 	upstreamBranch := integrations.FindCompareBranch()
 
-	return runCommitsar(".", upstreamBranch, debug, strict)
+	return runCommitsar(".", upstreamBranch, debug, strict, args...)
 }

--- a/cmd/root_runner.go
+++ b/cmd/root_runner.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
-func runCommitsar(pathToRepo, upstreamBranch string, debug, strict bool) error {
+func runCommitsar(pathToRepo, upstreamBranch string, debug, strict bool, args ...string) error {
 	fmt.Print("Starting analysis of commits on branch\n")
 
 	gitRepo, err := history.OpenGit(pathToRepo, debug)
@@ -20,36 +20,24 @@ func runCommitsar(pathToRepo, upstreamBranch string, debug, strict bool) error {
 		return err
 	}
 
-	currentBranch, currentBranchErr := gitRepo.CurrentBranch()
-	if currentBranchErr != nil {
-		return currentBranchErr
-	}
-
 	var commits []plumbing.Hash
 
-	sameBranch, err := IdentifySameBranch(currentBranch.Name().String(), upstreamBranch, gitRepo)
-
-	if err != nil {
-		return err
-	}
-
-	if sameBranch {
-		commitsOnSameBranch, err := gitRepo.CommitsOnBranch(currentBranch.Hash())
+	if len(args) == 0 {
+		commitsBetweenBranches, err := commitsBetweenBranches(gitRepo, upstreamBranch)
 
 		if err != nil {
 			return err
 		}
 
-		commits = append(commits, commitsOnSameBranch[0])
-
+		commits = commitsBetweenBranches
 	} else {
-		commitsOnBranch, err := gitRepo.BranchDiffCommits(currentBranch.Name().String(), upstreamBranch)
+		commitsBetweenHashes, err := commitsBetweenHashes(gitRepo, args)
 
 		if err != nil {
 			return err
 		}
 
-		commits = commitsOnBranch
+		commits = commitsBetweenHashes
 	}
 
 	var filteredCommits []plumbing.Hash

--- a/cmd/root_runner_test.go
+++ b/cmd/root_runner_test.go
@@ -17,3 +17,9 @@ func TestCommitsOnBranch(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestFromToCommits(t *testing.T) {
+	err := runCommitsar("../testdata/commits-on-different-branches", "master", false, true, "7dbf3e7db93ae2e02902cae9d2f1de1b1e5c8c92...d0240d3ed34685d0a5329b185e120d3e8c205be4")
+
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
- separates out commitsBetweenHashes and commitsBetweenBranches logic
- adds new argument for CLI
- adds new Flags section in README
- adds description for running commitsar with the argument for FROM...TO commit

References #165