### PR TITLE
fix: reverse order of from...to to to...from to reflect git log usage

### DIFF
--- a/internal/root_runner/commits_between_hashes.go
+++ b/internal/root_runner/commits_between_hashes.go
@@ -29,8 +29,8 @@ func commitsBetweenHashes(gitRepo *history.Git, args []string) ([]plumbing.Hash,
 	}
 
 	if len(splitArgs) == 2 {
-		fromCommit = plumbing.NewHash(splitArgs[0])
-		toCommit = plumbing.NewHash(splitArgs[1])
+		fromCommit = plumbing.NewHash(splitArgs[1])
+		toCommit = plumbing.NewHash(splitArgs[0])
 	}
 
 	logCommits, err := gitRepo.CommitsBetween(fromCommit, toCommit)

--- a/internal/root_runner/commits_between_hashes_test.go
+++ b/internal/root_runner/commits_between_hashes_test.go
@@ -12,10 +12,15 @@ func TestCommitsBetweenHashes(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	commits, err := commitsBetweenHashes(gitRepo, []string{"7dbf3e7db93ae2e02902cae9d2f1de1b1e5c8c92...d0240d3ed34685d0a5329b185e120d3e8c205be4"})
+	commits, err := commitsBetweenHashes(gitRepo, []string{"d0240d3ed34685d0a5329b185e120d3e8c205be4...7dbf3e7db93ae2e02902cae9d2f1de1b1e5c8c92"})
 
 	// TODO: Allow including to commit
 	assert.Len(t, commits, 1)
+	assert.NoError(t, err)
+
+	commit, err := gitRepo.Commit(commits[0])
+
+	assert.Equal(t, "feat: second commit on master\n", commit.Message)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
By using the same order feature parity is kept.

References #165