### PR TITLE
fix(cmd): to...from was broken since adding version command

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -53,6 +53,7 @@ func main() {
 		RunE:          runRoot,
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		Args: cobra.MinimumNArgs(0),
 	}
 
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")


### PR DESCRIPTION
RootCmd requires a MinimumArgs attribute to be filled in order to expect args.

See: https://github.com/spf13/cobra#example

References #165