### PR TITLE
refactor(logging): Use log.Logger for logging instead of debug flag

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/outillage/commitsar/internal/version_runner"
+	"io/ioutil"
 	"log"
 	"os"
 
@@ -42,7 +43,23 @@ func runRoot(cmd *cobra.Command, args []string) error {
 
 	upstreamBranch := integrations.FindCompareBranch()
 
-	return root_runner.RunCommitsar(".", upstreamBranch, debug, strict, args...)
+	debugLogger := log.Logger{}
+	debugLogger.SetPrefix("[DEBUG] ")
+	debugLogger.SetOutput(os.Stdout)
+
+	if !debug {
+		debugLogger.SetOutput(ioutil.Discard)
+		debugLogger.SetPrefix("")
+	}
+	
+	runner := root_runner.Runner{
+		DebugLogger: &debugLogger,
+		Logger:      log.New(os.Stdout, "", 0),
+		Strict:      strict,
+		Debug:       debug,
+	}
+
+	return runner.Run(".", upstreamBranch, args...)
 }
 
 func main() {

--- a/internal/root_runner/root_runner_test.go
+++ b/internal/root_runner/root_runner_test.go
@@ -1,25 +1,65 @@
 package root_runner
 
 import (
+	"bytes"
+	"io/ioutil"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCommitsOnMaster(t *testing.T) {
-	err := RunCommitsar("../../testdata/commits-on-master", "master", false, true)
+	var testString bytes.Buffer
+
+	testLogger := log.Logger{}
+	testLogger.SetOutput(&testString)
+
+	runner := Runner{
+		DebugLogger: log.New(ioutil.Discard, "", 0),
+		Logger:      &testLogger,
+		Strict:      false,
+		Debug:       false,
+	}
+
+	err := runner.Run("../../testdata/commits-on-master", "master" )
 
 	assert.NoError(t, err)
+	assert.Equal(t, "Starting analysis of commits on branch\n\n0 commits filtered out\n\nFound 1 commit to check\n\x1b[32mAll 1 commits are conventional commit compliant\n\x1b[0m\n", testString.String())
 }
 
 func TestCommitsOnBranch(t *testing.T) {
-	err := RunCommitsar("../../testdata/commits-on-different-branches", "master", false, true)
+	var testString bytes.Buffer
+
+	testLogger := log.Logger{}
+	testLogger.SetOutput(&testString)
+
+	runner := Runner{
+		DebugLogger: log.New(ioutil.Discard, "", 0),
+		Logger:      &testLogger,
+		Strict:      false,
+		Debug:       false,
+	}
+
+	err := runner.Run("../../testdata/commits-on-different-branches", "master")
 
 	assert.Error(t, err)
 }
 
 func TestFromToCommits(t *testing.T) {
-	err := RunCommitsar("../../testdata/commits-on-different-branches", "master", false, true, "7dbf3e7db93ae2e02902cae9d2f1de1b1e5c8c92...d0240d3ed34685d0a5329b185e120d3e8c205be4")
+	var testString bytes.Buffer
+
+	testLogger := log.Logger{}
+	testLogger.SetOutput(&testString)
+
+	runner := Runner{
+		DebugLogger: log.New(ioutil.Discard, "", 0),
+		Logger:      &testLogger,
+		Strict:      false,
+		Debug:       false,
+	}
+
+	err := runner.Run("../../testdata/commits-on-different-branches", "master", "7dbf3e7db93ae2e02902cae9d2f1de1b1e5c8c92...d0240d3ed34685d0a5329b185e120d3e8c205be4")
 
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Allows for much nicer code with fewer if debug {}

Closes #88