### PR TITLE
feat: skip initial commit messages

### DIFF
--- a/internal/root_runner/root_runner.go
+++ b/internal/root_runner/root_runner.go
@@ -60,7 +60,7 @@ func (runner *Runner) Run(pathToRepo, upstreamBranch string, args ...string) err
 			return commitErr
 		}
 
-		if !text.IsMergeCommit(commitObject.Message) {
+		if !text.IsMergeCommit(commitObject.Message) && !text.IsInitialCommit(commitObject.Message) {
 			filteredCommits = append(filteredCommits, commitHash)
 		}
 	}

--- a/pkg/text/is_initial_commit.go
+++ b/pkg/text/is_initial_commit.go
@@ -1,0 +1,12 @@
+package text
+
+import "regexp"
+
+var initCommitRegex = regexp.MustCompile(`^Initial .+`)
+
+// IsInitialCommit checks if a commit needs to be filtered, because it is the init commit of any given repo
+func IsInitialCommit(commitMessage string) bool{
+	initCommitMatch := initCommitRegex.FindStringSubmatch(commitMessage)
+
+	return initCommitMatch != nil
+}

--- a/pkg/text/is_initial_commit_test.go
+++ b/pkg/text/is_initial_commit_test.go
@@ -1,0 +1,16 @@
+package text
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIsInitialCommit(t *testing.T) {
+	tests := map[string]bool {
+		"Initial commit": true,
+	}
+
+	for test, expected := range tests {
+		assert.Equal(t, expected, IsInitialCommit(test))
+	}
+}


### PR DESCRIPTION
Currently it is impossible to run commitsar with Initial Commit messages which are common place in a lot of repositories