### PR TITLE
refactor: use struct for RootRunner Run method

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -21,6 +21,9 @@ var Strict bool
 // Dir is the location of repo to check
 var Dir string
 
+// AllCommits will iterate through all the commits on a branch
+var AllCommits bool
+
 // version is a global variable passed during build time
 var version string
 
@@ -51,15 +54,19 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		debugLogger.SetOutput(ioutil.Discard)
 		debugLogger.SetPrefix("")
 	}
-	
-	runner := root_runner.Runner{
-		DebugLogger: &debugLogger,
-		Logger:      log.New(os.Stdout, "", 0),
-		Strict:      strict,
-		Debug:       debug,
+
+	logger := log.New(os.Stdout, "", 0)
+
+	runner := root_runner.New(logger, &debugLogger, strict)
+
+	options := root_runner.RunnerOptions{
+		Path:           ".",
+		UpstreamBranch: upstreamBranch,
+		Limit:          0,
+		AllCommits:     AllCommits,
 	}
 
-	return runner.Run(".", upstreamBranch, args...)
+	return runner.Run(options, args...)
 }
 
 func main() {
@@ -76,6 +83,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&Strict, "strict", "s", true, "strict mode")
 	rootCmd.PersistentFlags().StringVarP(&Dir, "path", "d", ".", "dir points to the path of the repository")
+	rootCmd.PersistentFlags().BoolVarP(&AllCommits, "all", "a", false, "iterate through all the commits on the branch")
 
 	// Version returns undefined if not on a tag. This needs to reset it.
 	if version == "undefined" {

--- a/internal/root_runner/root_runner.go
+++ b/internal/root_runner/root_runner.go
@@ -1,14 +1,9 @@
 package root_runner
 
 import (
-	"errors"
+	"io/ioutil"
 	"log"
-
-	"github.com/logrusorgru/aurora"
-	"github.com/outillage/commitsar/pkg/text"
-	history "github.com/outillage/git/v2"
-	"github.com/outillage/quoad"
-	"gopkg.in/src-d/go-git.v4/plumbing"
+	"os"
 )
 
 type Runner struct {
@@ -19,93 +14,29 @@ type Runner struct {
 	Debug bool
 }
 
-// Run executes the base command for Commitsar
-func (runner *Runner) Run(pathToRepo, upstreamBranch string, args ...string) error {
-	runner.Logger.Print("Starting analysis of commits on branch\n")
+type RunnerOptions struct {
+	// Path to repository
+	Path string
+	// UpstreamBranch is the branch against which to check
+	UpstreamBranch string
+	// Limit will limit how far back to check on upstream branch.
+	Limit int
+	// AllCommits will check all the commits on the upstream branch. Regardless of Limit setting.
+	AllCommits bool
+}
 
-	gitRepo, err := history.OpenGit(pathToRepo, runner.DebugLogger)
-
-	if err != nil {
-		return err
+// New returns a new instance of a RootRunner with fallbacks for logging
+func New(logger *log.Logger, debugLogger *log.Logger, strict bool) *Runner{
+	if logger == nil {
+		logger = log.New(os.Stdout, "", 0)
+	}
+	if debugLogger == nil {
+		debugLogger = log.New(ioutil.Discard, "[DEBUG] ", 0)
 	}
 
-	var commits []plumbing.Hash
-
-	if len(args) == 0 {
-		commitsBetweenBranches, err := commitsBetweenBranches(gitRepo, upstreamBranch)
-
-		if err != nil {
-			return err
-		}
-
-		commits = commitsBetweenBranches
-	} else {
-		commitsBetweenHashes, err := commitsBetweenHashes(gitRepo, args)
-
-		if err != nil {
-			return err
-		}
-
-		commits = commitsBetweenHashes
+	return &Runner{
+		Logger:logger,
+		DebugLogger:debugLogger,
+		Strict:strict,
 	}
-
-	var filteredCommits []plumbing.Hash
-
-	for _, commitHash := range commits {
-		commitObject, commitErr := gitRepo.Commit(commitHash)
-
-		runner.DebugLogger.Printf("Commit found: [hash] %v [message] %v \n", commitObject.Hash, text.MessageTitle(commitObject.Message))
-
-		if commitErr != nil {
-			return commitErr
-		}
-
-		if !text.IsMergeCommit(commitObject.Message) && !text.IsInitialCommit(commitObject.Message) {
-			filteredCommits = append(filteredCommits, commitHash)
-		}
-	}
-
-	runner.Logger.Printf("\n%v commits filtered out\n", len(commits)-len(filteredCommits))
-	runner.Logger.Printf("\nFound %v commit to check\n", len(filteredCommits))
-
-	if len(filteredCommits) == 0 {
-		return errors.New(aurora.Red("No commits found, please check you are on a branch outside of main").String())
-	}
-
-	var faultyCommits []text.FailingCommit
-
-	for _, commitHash := range filteredCommits {
-		commitObject, commitErr := gitRepo.Commit(commitHash)
-
-		if commitErr != nil {
-			return commitErr
-		}
-
-		messageTitle := text.MessageTitle(commitObject.Message)
-
-		parsedCommit := quoad.ParseCommitMessage(commitObject.Message)
-
-		textErr := text.CheckMessageTitle(parsedCommit, runner.Strict)
-
-		if textErr != nil {
-			faultyCommits = append(faultyCommits, text.FailingCommit{Hash: commitHash.String(), Message: messageTitle, Error: textErr})
-		}
-	}
-
-	if len(faultyCommits) != 0 {
-		failingCommitMessage := text.FormatFailingCommits(faultyCommits)
-
-		runner.Logger.Print(failingCommitMessage)
-
-		runner.Logger.Printf("%v of %v commits are not conventional commit compliant\n", aurora.Red(len(faultyCommits)), aurora.Red(len(commits)))
-
-		runner.Logger.Print("\nExpected format is for example:      chore(ci): this is a test\n")
-		runner.Logger.Print("Please see https://www.conventionalcommits.org for help on how to structure commits\n\n")
-
-		return errors.New(aurora.Red("Not all commits are conventiontal commits, please check the commits listed above").String())
-	}
-
-	runner.Logger.Print(aurora.Sprintf(aurora.Green("All %v commits are conventional commit compliant\n"), len(filteredCommits)))
-
-	return nil
 }

--- a/internal/root_runner/run.go
+++ b/internal/root_runner/run.go
@@ -1,0 +1,102 @@
+package root_runner
+
+import (
+	"errors"
+
+	"github.com/logrusorgru/aurora"
+	"github.com/outillage/commitsar/pkg/text"
+	history "github.com/outillage/git/v2"
+	"github.com/outillage/quoad"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+)
+
+// Run executes the base command for Commitsar
+func (runner *Runner) Run(options RunnerOptions, args ...string) error {
+	runner.Logger.Print("Starting analysis of commits on branch\n")
+
+	gitRepo, err := history.OpenGit(options.Path, runner.DebugLogger)
+
+	if err != nil {
+		return err
+	}
+
+	var commits []plumbing.Hash
+
+	if len(args) == 0 {
+		commitsBetweenBranches, err := commitsBetweenBranches(gitRepo, options.UpstreamBranch)
+
+		if err != nil {
+			return err
+		}
+
+		commits = commitsBetweenBranches
+	} else {
+		commitsBetweenHashes, err := commitsBetweenHashes(gitRepo, args)
+
+		if err != nil {
+			return err
+		}
+
+		commits = commitsBetweenHashes
+	}
+
+	var filteredCommits []plumbing.Hash
+
+	for _, commitHash := range commits {
+		commitObject, commitErr := gitRepo.Commit(commitHash)
+
+		runner.DebugLogger.Printf("Commit found: [hash] %v [message] %v \n", commitObject.Hash, text.MessageTitle(commitObject.Message))
+
+		if commitErr != nil {
+			return commitErr
+		}
+
+		if !text.IsMergeCommit(commitObject.Message) && !text.IsInitialCommit(commitObject.Message) {
+			filteredCommits = append(filteredCommits, commitHash)
+		}
+	}
+
+	runner.Logger.Printf("\n%v commits filtered out\n", len(commits)-len(filteredCommits))
+	runner.Logger.Printf("\nFound %v commit to check\n", len(filteredCommits))
+
+	if len(filteredCommits) == 0 {
+		return errors.New(aurora.Red("No commits found, please check you are on a branch outside of main").String())
+	}
+
+	var faultyCommits []text.FailingCommit
+
+	for _, commitHash := range filteredCommits {
+		commitObject, commitErr := gitRepo.Commit(commitHash)
+
+		if commitErr != nil {
+			return commitErr
+		}
+
+		messageTitle := text.MessageTitle(commitObject.Message)
+
+		parsedCommit := quoad.ParseCommitMessage(commitObject.Message)
+
+		textErr := text.CheckMessageTitle(parsedCommit, runner.Strict)
+
+		if textErr != nil {
+			faultyCommits = append(faultyCommits, text.FailingCommit{Hash: commitHash.String(), Message: messageTitle, Error: textErr})
+		}
+	}
+
+	if len(faultyCommits) != 0 {
+		failingCommitMessage := text.FormatFailingCommits(faultyCommits)
+
+		runner.Logger.Print(failingCommitMessage)
+
+		runner.Logger.Printf("%v of %v commits are not conventional commit compliant\n", aurora.Red(len(faultyCommits)), aurora.Red(len(commits)))
+
+		runner.Logger.Print("\nExpected format is for example:      chore(ci): this is a test\n")
+		runner.Logger.Print("Please see https://www.conventionalcommits.org for help on how to structure commits\n\n")
+
+		return errors.New(aurora.Red("Not all commits are conventional commits, please check the commits listed above").String())
+	}
+
+	runner.Logger.Print(aurora.Sprintf(aurora.Green("All %v commits are conventional commit compliant\n"), len(filteredCommits)))
+
+	return nil
+}

--- a/internal/root_runner/run_test.go
+++ b/internal/root_runner/run_test.go
@@ -22,7 +22,14 @@ func TestCommitsOnMaster(t *testing.T) {
 		Debug:       false,
 	}
 
-	err := runner.Run("../../testdata/commits-on-master", "master" )
+	options := RunnerOptions{
+		Path:           "../../testdata/commits-on-master",
+		UpstreamBranch: "master",
+		Limit:          0,
+		AllCommits:     false,
+	}
+
+	err := runner.Run(options)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Starting analysis of commits on branch\n\n0 commits filtered out\n\nFound 1 commit to check\n\x1b[32mAll 1 commits are conventional commit compliant\n\x1b[0m\n", testString.String())
@@ -41,7 +48,14 @@ func TestCommitsOnBranch(t *testing.T) {
 		Debug:       false,
 	}
 
-	err := runner.Run("../../testdata/commits-on-different-branches", "master")
+	options := RunnerOptions{
+		Path:           "../../testdata/commits-on-different-branches",
+		UpstreamBranch: "master",
+		Limit:          0,
+		AllCommits:     false,
+	}
+
+	err := runner.Run(options, "master")
 
 	assert.Error(t, err)
 }
@@ -59,7 +73,14 @@ func TestFromToCommits(t *testing.T) {
 		Debug:       false,
 	}
 
-	err := runner.Run("../../testdata/commits-on-different-branches", "master", "7dbf3e7db93ae2e02902cae9d2f1de1b1e5c8c92...d0240d3ed34685d0a5329b185e120d3e8c205be4")
+	options := RunnerOptions{
+		Path:           "../../testdata/commits-on-different-branches",
+		UpstreamBranch: "master",
+		Limit:          0,
+		AllCommits:     false,
+	}
+
+	err := runner.Run(options, "7dbf3e7db93ae2e02902cae9d2f1de1b1e5c8c92...d0240d3ed34685d0a5329b185e120d3e8c205be4")
 
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
The arguments for RootRunner.Run kept getting bigger. This will consolidate it in one spot and allow for better defaults and checking.