### PR TITLE
feature: --all flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ Adjust for version and distribution. Please check [Releases](https://github.com/
 
 Commitsar allows the following flags:
 
-| Name    | Flag | Required | Default |
-| ------- | ---- | -------- | ------- |
-| Verbose | --v  | false    | false   |
-| Strict  | --s  | false    | true    |
+| Name    | Flag  | Required | Default | Description                                                                        |
+| ------- | ----- | -------- | ------- | ---------------------------------------------------------------------------------- |
+| Verbose | --v   | false    | false   | Debug output into console                                                          |
+| Strict  | --s   | false    | true    | Strict check of category types                                                     |
+| All     | --all | false    | false   | Whether to check all commits on given branch. **Takes precedence over LIMIT flag** |
 
 On top of that a single argument is allowed:
 

--- a/internal/root_runner/commits_between_branches_test.go
+++ b/internal/root_runner/commits_between_branches_test.go
@@ -1,0 +1,64 @@
+package root_runner
+
+import (
+	"testing"
+
+	history "github.com/outillage/git/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllCommits(t *testing.T) {
+	gitRepo, err := history.OpenGit("../../testdata/long-history", nil)
+
+	assert.NoError(t, err)
+
+	options := RunnerOptions{
+		Path:           "",
+		UpstreamBranch: "master",
+		Limit:          0,
+		AllCommits:     true,
+	}
+
+	commits, err := commitsBetweenBranches(gitRepo, options)
+
+	assert.NoError(t, err)
+	assert.Len(t, commits, 102)
+
+	lastCommit, err := gitRepo.Commit(commits[0])
+
+	assert.NoError(t, err)
+	assert.Equal(t, "chore: add 100 file\n", lastCommit.Message)
+
+	firstCommit, err := gitRepo.Commit(commits[101])
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Initial commit", firstCommit.Message)
+}
+
+func TestLimitCommits(t *testing.T) {
+	gitRepo, err := history.OpenGit("../../testdata/long-history", nil)
+
+	assert.NoError(t, err)
+
+	options := RunnerOptions{
+		Path:           "",
+		UpstreamBranch: "master",
+		Limit:          50,
+		AllCommits:     false,
+	}
+
+	commits, err := commitsBetweenBranches(gitRepo, options)
+
+	assert.NoError(t, err)
+	assert.Len(t, commits, 50)
+
+	lastCommit, err := gitRepo.Commit(commits[0])
+
+	assert.NoError(t, err)
+	assert.Equal(t, "chore: add 100 file\n", lastCommit.Message)
+
+	firstCommit, err := gitRepo.Commit(commits[49])
+
+	assert.NoError(t, err)
+	assert.Equal(t, "chore: add 51 file\n", firstCommit.Message)
+}

--- a/internal/root_runner/run.go
+++ b/internal/root_runner/run.go
@@ -23,7 +23,7 @@ func (runner *Runner) Run(options RunnerOptions, args ...string) error {
 	var commits []plumbing.Hash
 
 	if len(args) == 0 {
-		commitsBetweenBranches, err := commitsBetweenBranches(gitRepo, options.UpstreamBranch)
+		commitsBetweenBranches, err := commitsBetweenBranches(gitRepo, options)
 
 		if err != nil {
 			return err


### PR DESCRIPTION
This flag allows to opt into checking the entire upstream branch. 

This allows users to use it on whole repositories to check for any problematic commits.

Refs #187