### PR TITLE
fix(conventional standard)!: breaking changes do not require body

### DIFF
--- a/pkg/text/check_message_title.go
+++ b/pkg/text/check_message_title.go
@@ -18,7 +18,7 @@ var (
 
 	// Fields such as category and chore should contain only word characters
 	categoryRegex = regexp.MustCompile(`^\w+$`)
-	scopeRegex = regexp.MustCompile(`^\w+( \w+)*$`)
+	scopeRegex    = regexp.MustCompile(`^\w+( \w+)*$`)
 
 	// Commits with breaking changes should contain text with BREAKING CHANGE: at start
 	bcRegex = regexp.MustCompile(`^BREAKING CHANGE: `)
@@ -56,16 +56,6 @@ func CheckMessageTitle(commit quoad.Commit, strict bool) error {
 	scopeMatch := scopeRegex.FindStringSubmatch(commit.Scope)
 	if commit.Scope != "" && scopeMatch == nil {
 		return errScopeNonConform
-	}
-
-	if commit.Breaking {
-		if commit.Body == "" {
-			return errMissingBCBody
-		}
-		bcMatch := bcRegex.FindStringSubmatch(commit.Body)
-		if bcMatch == nil {
-			return errBCMissingText
-		}
 	}
 
 	return nil

--- a/pkg/text/check_message_title_test.go
+++ b/pkg/text/check_message_title_test.go
@@ -16,13 +16,9 @@ func TestCheckMessageTitleNonStrict(t *testing.T) {
 			quoad.Commit{Category: "test", Scope: "full", Heading: "a heading", Body: "body is here\nit can have multiple lines"},
 			quoad.Commit{Category: "test", Heading: "a heading", Body: "BREAKING CHANGE: this happened", Breaking: true},
 			quoad.Commit{Category: "chore", Scope: "new integration", Heading: "added new integration"},
-		},
-		errBCMissingText: []quoad.Commit{
-			quoad.Commit{Category: "test", Heading: "a heading", Body: "body is here", Breaking: true},
-		},
-		errMissingBCBody: []quoad.Commit{
 			quoad.Commit{Category: "fix", Breaking: true, Heading: "breaking change"},
 			quoad.Commit{Category: "fix", Scope: "security", Breaking: true, Heading: "breaking"},
+			quoad.Commit{Category: "test", Heading: "a heading", Body: "body is here", Breaking: true},
 		},
 		errCategoryWrongFormat: []quoad.Commit{
 			quoad.Commit{Category: "fix!", Breaking: true, Heading: "breaking"},
@@ -55,7 +51,7 @@ func TestCheckMessageTitleStrict(t *testing.T) {
 		tests[nil] = quoad.Commit{Category: cat, Heading: "add something"}
 	}
 
-	tests[errNonStandardCategory] =  quoad.Commit{Category: "thisshouldneverbeacategory", Heading: "add something"}
+	tests[errNonStandardCategory] = quoad.Commit{Category: "thisshouldneverbeacategory", Heading: "add something"}
 
 	for expected, test := range tests {
 		err := CheckMessageTitle(test, true)


### PR DESCRIPTION
BREAKING CHANGE: Commitsar will no longer fail if commit body is not present in a commit marked as a breaking change.